### PR TITLE
Update facet filter message for no results

### DIFF
--- a/filters.php
+++ b/filters.php
@@ -4,16 +4,42 @@ add_action( 'facetwp_scripts', function() { ?>
 <script>
 (function($) {
     $(function() {
+        // Before FacetWP refreshes, remove existing messages to avoid duplicates
+        FWP.hooks.addAction('facetwp/refresh', function() {
+            $('.facetwp-facet .no-results-message').remove();
+        });
+
+        // After FacetWP loads (initial and after interactions), add messages for empty facets
         FWP.hooks.addAction('facetwp/loaded', function() {
-            $('.facetwp-facet').each(function() {
-                var content = $(this).html();
-                if ('' == content) {
-                    $(this).append("<p class='no-results-message' style='color: #fff;''>Nothing found matching the selected criteria.</p>");
-                }				
-            });
+            try {
+                if (FWP && FWP.settings && FWP.settings.num_choices) {
+                    $.each(FWP.settings.num_choices, function(name, count) {
+                        var $facet = $('.facetwp-facet-' + name);
+                        $facet.find('.no-results-message').remove();
+                        var hasChoices = parseInt(count, 10) > 0;
+                        if (!hasChoices) {
+                            $facet.append("<p class='no-results-message' aria-live='polite'>Nothing found matching the selected criteria.</p>");
+                        }
+                    });
+                }
+                else {
+                    // Fallback: check for facets that render with no inner HTML
+                    $('.facetwp-facet').each(function() {
+                        var $facet = $(this);
+                        var content = $.trim($facet.html());
+                        $facet.find('.no-results-message').remove();
+                        if ('' === content) {
+                            $facet.append("<p class='no-results-message' aria-live='polite'>Nothing found matching the selected criteria.</p>");
+                        }
+                    });
+                }
+            }
+            catch (e) {
+                // No-op: avoid interrupting filtering UX
+            }
         }, 1000 );
     });
-})(fUtil);
+})((typeof jQuery !== 'undefined') ? jQuery : fUtil);
 </script>
 <?php }, 100 );
 


### PR DESCRIPTION
Update FacetsWP script to display 'no results' messages for facets after user interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-344d915c-2c27-4468-94a0-9c31d3e45c9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-344d915c-2c27-4468-94a0-9c31d3e45c9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

